### PR TITLE
xcftools_concat.sh handle empty xcf.bin files

### DIFF
--- a/snp-array-pipeline/tools/xcftools_concat/src/xcftools_concat.sh
+++ b/snp-array-pipeline/tools/xcftools_concat/src/xcftools_concat.sh
@@ -47,6 +47,9 @@ main() {
     echo "Using dxfuse version $(dxfuse -version)"
     dxfuse $MOUNTDIR /home/dnanexus/dxfuse_manifest.json
 
+#    ls -1v /mnt/project/${inp_pfx}*.bcf > list.txt #GD_updated this line
+find /mnt/project/${inp_pfx} -type f -name "*.bin" -size +0c | sed 's/\.bin$/.bcf/' > list.txt
+
     ls -1v /mnt/project/${inp_pfx}*.bcf > list.txt
     
     mode="--ligate"

--- a/snp-array-pipeline/tools/xcftools_concat/src/xcftools_concat.sh
+++ b/snp-array-pipeline/tools/xcftools_concat/src/xcftools_concat.sh
@@ -47,11 +47,9 @@ main() {
     echo "Using dxfuse version $(dxfuse -version)"
     dxfuse $MOUNTDIR /home/dnanexus/dxfuse_manifest.json
 
-#    ls -1v /mnt/project/${inp_pfx}*.bcf > list.txt #GD_updated this line
-find /mnt/project/${inp_pfx} -type f -name "*.bin" -size +0c | sed 's/\.bin$/.bcf/' > list.txt
+    # find only well-formed (non-empty) xcf.bcf files
+    ls -1vs "/mnt/project/${inp_pfx}"*.bin | awk '$1 > 0 { sub(/\.bin$/, ".bcf", $2); print $2 }' > list.txt
 
-    ls -1v /mnt/project/${inp_pfx}*.bcf > list.txt
-    
     mode="--ligate"
     if [ "$naive" = true ]; then
     	mode="--naive"


### PR DESCRIPTION
Hi Simone, 
Not sure about the right etiquette for dealing with this, but I've posted about the issue at the main xcftools git
[xcftools_concat.sh handle empty xcf.bin files](https://github.com/srubinacci/imputation-ukb-ref-panel/commit/e0bba7f65cc743190761a1c8556c02401f19060d)
